### PR TITLE
preserve NULLs on export

### DIFF
--- a/src/MySQLBackup.php
+++ b/src/MySQLBackup.php
@@ -471,7 +471,13 @@ class MySQLBackup
                         }
                         else
                         {
-                            $return .= '""';
+                            if($row[$i] === NULL)
+                            {
+                                $return .= 'NULL';
+                            }
+                            else {
+                                $return .= '""';
+                            }
                         }
                         
                         if ($i < ($num_fields-1))


### PR DESCRIPTION
NULLs from the DB would get converted to empty strings. i've tested this on our own db and finally had a successful reimport.